### PR TITLE
9 farmers dance causes issues with plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@
         <!-- Revision variable removes warning about dynamic version -->
         <revision>${build.version}-SNAPSHOT</revision>
         <!-- This allows to change between versions and snapshots. -->
-        <build.version>1.2.1</build.version>
+        <build.version>1.2.2</build.version>
         <build.number>-LOCAL</build.number>
     </properties>
 

--- a/src/main/java/world/bentobox/farmersdance/listeners/FastDancingListener.java
+++ b/src/main/java/world/bentobox/farmersdance/listeners/FastDancingListener.java
@@ -89,7 +89,8 @@ public class FastDancingListener extends DancingHandler implements Listener
 
         if (!this.checkIsland(event, player, player.getLocation(), FarmersDanceAddon.FARMER_DANCE, true))
         {
-            // Player is not allowed to dance on this island.
+            // Player is not allowed to dance on this island, but do not cancel the event
+            event.setCancelled(false);
             return;
         }
 

--- a/src/main/java/world/bentobox/farmersdance/listeners/LazyDancingListener.java
+++ b/src/main/java/world/bentobox/farmersdance/listeners/LazyDancingListener.java
@@ -79,7 +79,8 @@ public class LazyDancingListener extends DancingHandler implements Listener
 
         if (!this.checkIsland(event, player, player.getLocation(), FarmersDanceAddon.FARMER_DANCE, false))
         {
-            // Player is not allowed to dance on this island.
+            // Player is not allowed to dance on this island, but do not cancel the event
+            event.setCancelled(false);
             return;
         }
 


### PR DESCRIPTION
The sneak toggle event should not be canceled just because dancing is not allowed. The Flag checker cancels events automatically, so it is necessary to re-allow it. Should fix #9 